### PR TITLE
Fix FP16 gradients error in SFT training

### DIFF
--- a/modeling/llm_post_training/instruction_sft.py
+++ b/modeling/llm_post_training/instruction_sft.py
@@ -116,7 +116,8 @@ class InstructionSFTTrainer:
         self.log_dir = "debug_logs"
         os.makedirs(self.log_dir, exist_ok=True)
         self.log_file = os.path.join(
-            self.log_dir, f"sft_debug_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+            self.log_dir,
+            f"sft_debug_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
         )
 
     def _get_model_name(self) -> str:
@@ -152,7 +153,9 @@ class InstructionSFTTrainer:
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model_name,
             cache_dir=self.models_dir,
-            torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
+            torch_dtype=(
+                torch.float16 if torch.cuda.is_available() else torch.float32
+            ),
             device_map="auto" if torch.cuda.is_available() else None,
             trust_remote_code=True,
         )
@@ -160,6 +163,9 @@ class InstructionSFTTrainer:
         # Apply LoRA if enabled
         if self.use_lora:
             self._apply_lora()
+
+        # Ensure parameters are in correct precision for mixed precision
+        self._ensure_correct_precision()
 
     def _apply_lora(self) -> None:
         """Apply LoRA configuration to the model."""
@@ -184,6 +190,51 @@ class InstructionSFTTrainer:
 
         self.model = get_peft_model(self.model, lora_config)
         self.model.print_trainable_parameters()
+
+        # Fix for FP16 gradients error: ensure trainable parameters are in FP32
+        # when using mixed precision training
+        print(
+            "🔧 Converting trainable parameters to FP32 for "
+            "mixed precision compatibility..."
+        )
+        for param in self.model.parameters():
+            if param.requires_grad:
+                param.data = param.data.float()
+
+    def _ensure_correct_precision(self) -> None:
+        """
+        Ensure model parameters are in the correct precision for mixed precision.
+
+        This method fixes the 'Attempting to unscale FP16 gradients' error by
+        ensuring that all trainable parameters are in FP32 when using mixed
+        precision training. AMP expects trainable parameters to be in FP32 and
+        handles casting to FP16 during the forward pass.
+        """
+        # Only apply when using GPU with mixed precision
+        if torch.cuda.is_available():
+            print(
+                "🔧 Ensuring correct precision for mixed precision training..."
+            )
+            trainable_params = 0
+            converted_params = 0
+
+            for param in self.model.parameters():
+                if param.requires_grad:
+                    trainable_params += 1
+                    if param.dtype == torch.float16:
+                        param.data = param.data.float()
+                        converted_params += 1
+
+            if converted_params > 0:
+                print(
+                    f"   Converted {converted_params}/{trainable_params} "
+                    f"trainable parameters from FP16 to FP32"
+                )
+            else:
+                print(
+                    f"   All {trainable_params} trainable parameters "
+                    f"already in correct precision"
+                )
 
     def load_and_prepare_dataset(self) -> None:
         """Load and prepare the Alpaca dataset."""
@@ -344,7 +395,7 @@ class InstructionSFTTrainer:
             args=training_args,
             train_dataset=self.dataset,
             data_collator=data_collator,
-            tokenizer=self.tokenizer,
+            processing_class=self.tokenizer,  # Use processing_class instead of deprecated tokenizer
         )
 
         # Validate dataset before training

--- a/modeling/llm_post_training/instruction_sft.py
+++ b/modeling/llm_post_training/instruction_sft.py
@@ -116,8 +116,7 @@ class InstructionSFTTrainer:
         self.log_dir = "debug_logs"
         os.makedirs(self.log_dir, exist_ok=True)
         self.log_file = os.path.join(
-            self.log_dir,
-            f"sft_debug_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+            self.log_dir, f"sft_debug_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
         )
 
     def _get_model_name(self) -> str:
@@ -153,9 +152,7 @@ class InstructionSFTTrainer:
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model_name,
             cache_dir=self.models_dir,
-            torch_dtype=(
-                torch.float16 if torch.cuda.is_available() else torch.float32
-            ),
+            torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
             device_map="auto" if torch.cuda.is_available() else None,
             trust_remote_code=True,
         )
@@ -212,9 +209,7 @@ class InstructionSFTTrainer:
         """
         # Only apply when using GPU with mixed precision
         if torch.cuda.is_available():
-            print(
-                "🔧 Ensuring correct precision for mixed precision training..."
-            )
+            print("🔧 Ensuring correct precision for mixed precision training...")
             trainable_params = 0
             converted_params = 0
 


### PR DESCRIPTION
- Fix 'ValueError: Attempting to unscale FP16 gradients' error that occurs when using mixed precision training with LoRA
- Add _ensure_correct_precision() method to convert trainable parameters from FP16 to FP32 before training
- Update _apply_lora() to ensure LoRA parameters are in FP32
- Fix deprecated tokenizer parameter warning by using processing_class
- Add detailed logging for parameter precision conversion

The issue occurred because AMP expects trainable parameters to be in FP32 and handles casting to FP16 during forward pass, but LoRA parameters were already in FP16 causing the unscaling error during gradient computation.