### PR TITLE
Fix RuntimeWarnings in autoencoder training module

### DIFF
--- a/modeling/generation/__init__.py
+++ b/modeling/generation/__init__.py
@@ -2,12 +2,10 @@
 
 from .celeba_dataloader import CelebADataLoader, create_celeba_dataloader
 from .ae.autoencoder import AutoEncoder, create_autoencoder
-from .ae.train_autoencoder import AutoEncoderTrainer
 
 __all__ = [
     "CelebADataLoader",
     "create_celeba_dataloader",
     "AutoEncoder",
     "create_autoencoder",
-    "AutoEncoderTrainer",
 ]

--- a/modeling/generation/ae/__init__.py
+++ b/modeling/generation/ae/__init__.py
@@ -1,7 +1,6 @@
 """Auto-encoder module for generation tasks."""
 
 from .autoencoder import AutoEncoder, create_autoencoder
-from .train_autoencoder import AutoEncoderTrainer
 
 # Conditional import for inference module to avoid dependency issues
 try:
@@ -10,12 +9,10 @@ try:
     __all__ = [
         "AutoEncoder",
         "create_autoencoder",
-        "AutoEncoderTrainer",
         "AutoEncoderInference",
     ]
 except ImportError:
     __all__ = [
         "AutoEncoder",
         "create_autoencoder",
-        "AutoEncoderTrainer",
     ]


### PR DESCRIPTION
- Remove AutoEncoderTrainer import from ae/__init__.py to prevent circular imports
- Remove AutoEncoderTrainer import from generation/__init__.py
- Training modules should not be imported at package level to avoid conflicts
- Resolves warnings when running: python -m modeling.generation.ae.train_autoencoder