### PR TITLE
feat: save models only after training completion

### DIFF
--- a/modeling/generation/ae/train_autoencoder.py
+++ b/modeling/generation/ae/train_autoencoder.py
@@ -386,7 +386,6 @@ class AutoEncoderTrainer:
     def train(
         self,
         num_epochs: int,
-        save_every: int = 10,
         validate_every: int = 1,
         log_reconstructions_every: int = 5,
     ) -> None:
@@ -395,7 +394,6 @@ class AutoEncoderTrainer:
 
         Args:
             num_epochs: Number of epochs to train
-            save_every: Save checkpoint every N epochs
             validate_every: Validate every N epochs
             log_reconstructions_every: Log reconstructions every N epochs
         """
@@ -433,13 +431,15 @@ class AutoEncoderTrainer:
                 if self.scheduler is not None and not self.step_level_scheduling:
                     self.scheduler.step()
 
-            # Save checkpoint
-            if (epoch + 1) % save_every == 0:
-                self.save_checkpoint(epoch + 1)
+            # Note: Checkpoint saving removed - model will only be saved after training completion
 
             # Log reconstructions to wandb
             if (epoch + 1) % log_reconstructions_every == 0:
                 self.log_reconstructions(epoch=epoch + 1)
+
+        # Save final model after training completion
+        self.save_checkpoint(self.current_epoch, is_best=False)
+        logger.info(f"Saved final model after training completion (epoch {self.current_epoch})")
 
         # Log final training history
         self.log_training_history()
@@ -542,7 +542,6 @@ def main():
     # Train
     trainer.train(
         num_epochs=config["num_epochs"],
-        save_every=10,
         validate_every=1,
         log_reconstructions_every=5,
     )

--- a/modeling/generation/ae/train_vae.py
+++ b/modeling/generation/ae/train_vae.py
@@ -582,7 +582,6 @@ class VAETrainer:
     def train(
         self,
         num_epochs: int,
-        save_every: int = 10,
         validate_every: int = 1,
         log_reconstructions_every: int = 5,
         log_generated_every: int = 10,
@@ -592,7 +591,6 @@ class VAETrainer:
 
         Args:
             num_epochs: Number of epochs to train
-            save_every: Save checkpoint every N epochs
             validate_every: Validate every N epochs
             log_reconstructions_every: Log reconstructions every N epochs
             log_generated_every: Log generated samples every N epochs
@@ -666,9 +664,7 @@ class VAETrainer:
                 if self.scheduler is not None and not self.step_level_scheduling:
                     self.scheduler.step()
 
-            # Save checkpoint
-            if (epoch + 1) % save_every == 0:
-                self.save_checkpoint(epoch + 1)
+            # Note: Checkpoint saving removed - model will only be saved after training completion
 
             # Log reconstructions to wandb
             if (epoch + 1) % log_reconstructions_every == 0:
@@ -677,6 +673,10 @@ class VAETrainer:
             # Log generated samples to wandb
             if (epoch + 1) % log_generated_every == 0:
                 self.log_generated_samples(epoch=epoch + 1)
+
+        # Save final model after training completion
+        self.save_checkpoint(self.current_epoch, is_best=False)
+        logger.info(f"Saved final model after training completion (epoch {self.current_epoch})")
 
         # Log final training history
         self.log_training_history()
@@ -792,7 +792,6 @@ def main():
     # Train
     trainer.train(
         num_epochs=config["num_epochs"],
-        save_every=10,
         validate_every=1,
         log_reconstructions_every=5,
         log_generated_every=10,


### PR DESCRIPTION
- Remove periodic checkpoint saving during training epochs
- Keep best model saving for early stopping functionality
- Add final model save at end of training
- Update method signatures to remove save_every parameter
- Apply changes to both VAE and autoencoder training scripts

This reduces disk I/O during training and only saves the final trained model, while preserving the ability to save the best model during early stopping.