### PR TITLE
feat: Add support for messages format and HF dataset names in SFT script

### DIFF
--- a/modeling/llm_post_training/instruction_sft.py
+++ b/modeling/llm_post_training/instruction_sft.py
@@ -19,7 +19,8 @@ Usage:
 
     # Continue SFT from local checkpoint
     python instruction_sft.py --checkpoint-path ./models/Llama-3.2-3B-Full-SFT \
-        --dataset-name tech-tao/gang-jing_contrarian_sft_data
+        --dataset-name tech-tao/gang-jing_contrarian_sft_data \
+        --dataset-format messages
 
     # Continue SFT from Hugging Face model
     python instruction_sft.py --checkpoint-path microsoft/DialoGPT-medium
@@ -231,7 +232,7 @@ def main(args):
         )
     training_args = TrainingArguments(
         output_dir=output_dir,
-        num_train_epochs=1,
+        num_train_epochs=args.num_epochs,
         per_device_train_batch_size=args.batch_size,
         warmup_steps=max(100, int(0.05 * max_steps)),
         max_steps=max_steps,
@@ -288,6 +289,9 @@ if __name__ == "__main__":
     parser.add_argument("--use-lora", action="store_true")
     parser.add_argument("--disable-wandb", action="store_true")
     parser.add_argument("--max-steps", type=int, default=10000)
+    parser.add_argument(
+        "--num-epochs", type=int, default=1, help="Number of training epochs"
+    )
     parser.add_argument("--batch-size", type=int, default=8)
     parser.add_argument("--learning-rate", type=float, default=5e-6)
     parser.add_argument(

--- a/modeling/llm_post_training/instruction_sft.py
+++ b/modeling/llm_post_training/instruction_sft.py
@@ -18,7 +18,8 @@ Usage:
         --dataset-name HuggingFaceH4/ultrachat_200k
 
     # Continue SFT from local checkpoint
-    python instruction_sft.py --checkpoint-path ./models/Llama-3.2-3B-Full-SFT
+    python instruction_sft.py --checkpoint-path ./models/Llama-3.2-3B-Full-SFT \
+        --dataset-name tech-tao/gang-jing_contrarian_sft_data
 
     # Continue SFT from Hugging Face model
     python instruction_sft.py --checkpoint-path microsoft/DialoGPT-medium


### PR DESCRIPTION
- Add support for messages format dataset with single 'messages' column
- Restrict dataset loading to Hugging Face datasets by name only
- Add --dataset-format argument with choices: 'alpaca' or 'messages'
- Add --dataset-name argument for specifying HF dataset names
- Update format_messages() function to handle conversation format
- Maintain backward compatibility with existing Alpaca format
- Update documentation with new usage examples
- Remove local file support in favor of HF datasets only

Usage examples:
- Default: python instruction_sft.py --model-size 3B --use-lora
- Custom alpaca: python instruction_sft.py --model-size 3B --dataset-format alpaca --dataset-name microsoft/orca-math-word-problems-200k
- Messages format: python instruction_sft.py --model-size 3B --dataset-format messages --dataset-name HuggingFaceH4/ultrachat_200k