### PR TITLE
feat(basics): expand kv-cache benchmark diagnostics

### DIFF
--- a/modeling/basics/README.md
+++ b/modeling/basics/README.md
@@ -57,9 +57,23 @@ The tests check:
 uv run python -m modeling.basics.benchmark_kv_cache --device cpu
 ```
 
+Or sweep a few decode lengths in one run:
+
+```bash
+uv run python -m modeling.basics.benchmark_kv_cache --device cpu --seq-lens 32 64 128
+```
+
 This benchmark measures a realistic interview talking point:
 
 - without cache: recompute attention over the whole prefix at every decode step
 - with cache: reuse old `K/V` and only process the newest token
 
-It also prints the max output difference so we can verify the cached path is numerically aligned with the full causal path.
+It also prints:
+
+- `max_output_diff`: verifies the cached path stays numerically aligned with full causal attention
+- `measured_speedup`: the end-to-end timing difference on your device
+- `cache_hit_rate`: what fraction of attended `K/V` tokens came from cache instead of being newly projected
+- `kv_projection_reduction`: how much `K/V` projection work drops in the cached path
+- `attention_score_reduction`: how much attention-score work drops when we stop recomputing old query positions
+
+That makes it easier to explain both the empirical timing result and the theoretical reason KV cache helps.

--- a/modeling/basics/benchmark_kv_cache.py
+++ b/modeling/basics/benchmark_kv_cache.py
@@ -2,10 +2,53 @@
 
 import argparse
 import time
+from dataclasses import dataclass
 
 import torch
 
 from modeling.basics.attention import MHA, MHAWithKVCache, causal_mask
+
+
+@dataclass(frozen=True)
+class DecodeCost:
+    batch_size: int
+    seq_len: int
+    uncached_q_tokens: int
+    uncached_kv_tokens: int
+    cached_q_tokens: int
+    cached_kv_tokens: int
+    cached_reused_kv_tokens: int
+    uncached_attention_score_pairs: int
+    cached_attention_score_pairs: int
+
+    @property
+    def cache_hit_rate(self):
+        total_context_tokens = self.cached_kv_tokens + self.cached_reused_kv_tokens
+        return self.cached_reused_kv_tokens / total_context_tokens
+
+    @property
+    def kv_projection_reduction(self):
+        return self.uncached_kv_tokens / self.cached_kv_tokens
+
+    @property
+    def attention_score_reduction(self):
+        return self.uncached_attention_score_pairs / self.cached_attention_score_pairs
+
+
+def compute_decode_cost(batch_size, seq_len):
+    prefix_sum = seq_len * (seq_len + 1) // 2
+    prefix_square_sum = seq_len * (seq_len + 1) * (2 * seq_len + 1) // 6
+    return DecodeCost(
+        batch_size=batch_size,
+        seq_len=seq_len,
+        uncached_q_tokens=batch_size * prefix_sum,
+        uncached_kv_tokens=batch_size * prefix_sum,
+        cached_q_tokens=batch_size * seq_len,
+        cached_kv_tokens=batch_size * seq_len,
+        cached_reused_kv_tokens=batch_size * seq_len * (seq_len - 1) // 2,
+        uncached_attention_score_pairs=batch_size * prefix_square_sum,
+        cached_attention_score_pairs=batch_size * prefix_sum,
+    )
 
 
 def _sync_if_needed(device):
@@ -49,19 +92,9 @@ def benchmark(fn, warmup, iters, device):
     return (time.perf_counter() - start) / iters
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--batch-size", type=int, default=4)
-    parser.add_argument("--seq-len", type=int, default=128)
-    parser.add_argument("--d-model", type=int, default=256)
-    parser.add_argument("--n-heads", type=int, default=8)
-    parser.add_argument("--warmup", type=int, default=3)
-    parser.add_argument("--iters", type=int, default=10)
-    parser.add_argument("--device", default="cpu")
-    args = parser.parse_args()
-
+def run_case(args, seq_len):
     device = torch.device(args.device)
-    x = torch.randn(args.batch_size, args.seq_len, args.d_model, device=device)
+    x = torch.randn(args.batch_size, seq_len, args.d_model, device=device)
 
     mha = MHA(args.d_model, args.n_heads).to(device).eval()
     cached = MHAWithKVCache(args.d_model, args.n_heads).to(device).eval()
@@ -83,15 +116,53 @@ def main():
         iters=args.iters,
         device=device,
     )
+    return {
+        "device": device.type,
+        "max_diff": max_diff,
+        "uncached_s": uncached_s,
+        "cached_s": cached_s,
+        "cost": compute_decode_cost(args.batch_size, seq_len),
+    }
 
+
+def print_case(metrics, d_model, n_heads):
+    cost = metrics["cost"]
+    uncached_ms = metrics["uncached_s"] * 1000
+    cached_ms = metrics["cached_s"] * 1000
     print(
-        f"device={device.type} batch={args.batch_size} seq_len={args.seq_len} "
-        f"d_model={args.d_model} n_heads={args.n_heads}"
+        f"device={metrics['device']} batch={cost.batch_size} seq_len={cost.seq_len} "
+        f"d_model={d_model} n_heads={n_heads}"
     )
-    print(f"max_output_diff={max_diff:.3e}")
-    print(f"without_cache={uncached_s * 1000:.2f} ms")
-    print(f"with_cache={cached_s * 1000:.2f} ms")
-    print(f"speedup={uncached_s / cached_s:.2f}x")
+    print(f"max_output_diff={metrics['max_diff']:.3e}")
+    print(f"without_cache={uncached_ms:.2f} ms")
+    print(f"with_cache={cached_ms:.2f} ms")
+    print(f"measured_speedup={metrics['uncached_s'] / metrics['cached_s']:.2f}x")
+    print(f"cache_hit_rate={cost.cache_hit_rate:.2%}")
+    print(f"kv_projection_reduction={cost.kv_projection_reduction:.2f}x")
+    print(f"attention_score_reduction={cost.attention_score_reduction:.2f}x")
+    print(f"uncached_kv_tokens={cost.uncached_kv_tokens}")
+    print(f"cached_new_kv_tokens={cost.cached_kv_tokens}")
+    print(f"cached_reused_kv_tokens={cost.cached_reused_kv_tokens}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--seq-len", type=int, default=128)
+    parser.add_argument("--seq-lens", type=int, nargs="+")
+    parser.add_argument("--d-model", type=int, default=256)
+    parser.add_argument("--n-heads", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=10)
+    parser.add_argument("--device", default="cpu")
+    args = parser.parse_args()
+    seq_lens = args.seq_lens or [args.seq_len]
+
+    for idx, seq_len in enumerate(seq_lens):
+        metrics = run_case(args, seq_len)
+        print_case(metrics, d_model=args.d_model, n_heads=args.n_heads)
+        if idx != len(seq_lens) - 1:
+            print()
 
 
 if __name__ == "__main__":

--- a/tests/modeling/basics/test_benchmark_kv_cache.py
+++ b/tests/modeling/basics/test_benchmark_kv_cache.py
@@ -1,0 +1,21 @@
+from modeling.basics.benchmark_kv_cache import compute_decode_cost
+
+
+def test_decode_cost_matches_closed_form_counts():
+    cost = compute_decode_cost(batch_size=2, seq_len=4)
+
+    assert cost.uncached_q_tokens == 20
+    assert cost.uncached_kv_tokens == 20
+    assert cost.cached_q_tokens == 8
+    assert cost.cached_kv_tokens == 8
+    assert cost.cached_reused_kv_tokens == 12
+    assert cost.uncached_attention_score_pairs == 60
+    assert cost.cached_attention_score_pairs == 20
+
+
+def test_decode_cost_reports_cache_hit_rate_and_reductions():
+    cost = compute_decode_cost(batch_size=1, seq_len=8)
+
+    assert cost.cache_hit_rate == 28 / 36
+    assert cost.kv_projection_reduction == 36 / 8
+    assert cost.attention_score_reduction == 204 / 36


### PR DESCRIPTION
## Summary
- expand the KV-cache benchmark to report cache-hit and work-reduction diagnostics alongside timing
- add a closed-form cost helper and regression tests for the benchmark metrics
- document single-run and multi-seq-length benchmark usage in the basics README

## Test Plan
- `uv run pytest tests/modeling/basics/test_attention.py tests/modeling/basics/test_benchmark_kv_cache.py`
- `uv run python -m modeling.basics.benchmark_kv_cache --device cpu --batch-size 1 --d-model 64 --n-heads 4 --warmup 1 --iters 5 --seq-lens 16 32 64`